### PR TITLE
fix: runtimeControllerTest

### DIFF
--- a/test-samples/metadata/src/runtimeTestController.test.ts
+++ b/test-samples/metadata/src/runtimeTestController.test.ts
@@ -24,7 +24,7 @@ const createEvent = <T extends Pick<Event, 'routeKey'> & Partial<Event>>(props: 
 
 beforeAll(() => {
   app = AppMetadata.fromTsConfig(require.resolve('@apimda/test-samples-metadata/tsconfig.json'));
-  handler = createAwsLambdaHandler(app.runtimeApp, new RuntimeTestController());
+  handler = createAwsLambdaHandler(app.runtimeApp, RuntimeTestController);
 });
 
 describe('Async initializer test', () => {


### PR DESCRIPTION
```createAwsLambdaHandler``` was expecting an app with just one controller. Lifted this restriction since we want to define the controller to be used for the Aws Lambda handler.

Also since the test-samples-metadata app contains more then one app, this test was broken and is fixed now.