### PR TITLE
fix: setting default Content-Type in runtime

### DIFF
--- a/packages/runtime-node/src/nodeRuntime.ts
+++ b/packages/runtime-node/src/nodeRuntime.ts
@@ -43,9 +43,6 @@ const sendResultResponse = (response: ServerResponse, result: RuntimeResult) => 
   for (const headerName in result.headers) {
     outgoingHeaders[headerName] = result.headers[headerName].toString();
   }
-  if (!result.headers['Content-Type']) {
-    outgoingHeaders['Content-Type'] = 'application/json';
-  }
 
   const cookies: string[] = [];
   for (const cookieName in result.cookies) {

--- a/packages/runtime/src/runtime.ts
+++ b/packages/runtime/src/runtime.ts
@@ -69,6 +69,10 @@ function successResult(out: RuntimeOutput, result: any): RuntimeResult {
   const isString = out.declaredTypeName === 'string';
   const body = isBinary ? (bodyResult as Buffer) : isString ? bodyResult : JSON.stringify(bodyResult);
 
+  if (!headers['Content-Type']) {
+    headers['Content-Type'] = isString ? 'text/plain' : 'application/json';
+  }
+
   return {
     statusCode,
     headers,

--- a/test-samples/metadata/src/runtimeTestController.test.ts
+++ b/test-samples/metadata/src/runtimeTestController.test.ts
@@ -122,3 +122,21 @@ describe('GenericResult tests', () => {
     expect(result.body).toStrictEqual(JSON.stringify(RuntimeTestController.genericResultValue));
   });
 });
+
+describe('Default Content-Type tests', () => {
+  test('text/plain Content-Type', async () => {
+    const routeKey = 'GET /testOptionalQuery';
+
+    const event = createEvent({ routeKey });
+    const result = await handler(event);
+    expect(result.headers!['Content-Type']).toBe('text/plain');
+  });
+
+  test('application/json Content-Type', async () => {
+    const routeKey = 'GET /apimdaResult';
+
+    const event = createEvent({ routeKey });
+    const result = await handler(event);
+    expect(result.headers!['Content-Type']).toBe('application/json');
+  });
+});


### PR DESCRIPTION
As of now only the node runtime defaults the ```Content-Type``` to ````application/json```. I moved the default  Content-Type setting one layer above to runtime. 

In case of a string return I set the default to 'text/plain'

Once https://github.com/apimda/apimda/pull/1 is approved I would  go head and also update the runtimeTestController.