### PR TITLE
feat: support arch in NpmVersionLayer

### DIFF
--- a/packages/deploy-cdk/src/npmLayerVersion.test.ts
+++ b/packages/deploy-cdk/src/npmLayerVersion.test.ts
@@ -5,12 +5,31 @@ import * as lambda from 'aws-cdk-lib/aws-lambda';
 import { NpmLayerVersion } from './npmLayerVersion';
 
 describe('NpmLayer', () => {
+  test('rejects multi-arch layers', () => {
+    const app = new cdk.App();
+    const stack = new cdk.Stack(app, 'ApimdaStack');
+    const lvProps = {
+      compatibleArchitectures: [lambda.Architecture.ARM_64, lambda.Architecture.X86_64],
+      compatibleRuntimes: [lambda.Runtime.NODEJS_16_X]
+    };
+    let err = undefined;
+    try {
+      const layer = new NpmLayerVersion(stack, 'NpmLayer', {
+        layerPath: '../../samples/user-api/src/deploy/layer',
+        layerVersionProps: lvProps
+      });
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeDefined();
+  });
+
   test('creates correct lambda layer', () => {
     const app = new cdk.App();
     const stack = new cdk.Stack(app, 'ApimdaStack');
     const lvProps = {
       removalPolicy: RemovalPolicy.DESTROY,
-      compatibleArchitectures: [lambda.Architecture.X86_64, lambda.Architecture.ARM_64],
+      compatibleArchitectures: [lambda.Architecture.ARM_64],
       compatibleRuntimes: [lambda.Runtime.NODEJS_16_X],
       description: 'sample description'
     };
@@ -25,7 +44,7 @@ describe('NpmLayer', () => {
     const template = Template.fromStack(stack);
     template.resourceCountIs('AWS::Lambda::LayerVersion', 1);
     template.hasResourceProperties('AWS::Lambda::LayerVersion', {
-      CompatibleArchitectures: ['x86_64', 'arm64'],
+      CompatibleArchitectures: ['arm64'],
       CompatibleRuntimes: ['nodejs16.x'],
       Description: 'sample description'
     });

--- a/packages/deploy-cdk/src/npmLayerVersion.ts
+++ b/packages/deploy-cdk/src/npmLayerVersion.ts
@@ -1,4 +1,4 @@
-import { Code, LayerVersion, LayerVersionProps } from 'aws-cdk-lib/aws-lambda';
+import { Architecture, Code, LayerVersion, LayerVersionProps } from 'aws-cdk-lib/aws-lambda';
 import { execSync } from 'child_process';
 import { Construct } from 'constructs';
 import * as fs from 'fs';
@@ -18,6 +18,11 @@ export interface NpmLayerVersionProps {
    */
   layerVersionProps?: Omit<LayerVersionProps, 'code'>;
 }
+
+const AWS_ARCH_TO_NODE_ARCH: Map<Architecture, string> = new Map([
+  [Architecture.X86_64, 'x64'],
+  [Architecture.ARM_64, 'arm64']
+]);
 
 /**
  * A lambda layer (LayerVersion) that is generated from package.json using npm.
@@ -42,9 +47,18 @@ export class NpmLayerVersion extends Construct {
     }
 
     const cwd = `${path.dirname(pkgFile)}`;
-    execSync('npm i --production', { cwd });
+    const awsArch = props.layerVersionProps?.compatibleArchitectures ?? [Architecture.X86_64];
+    if (awsArch.length != 1) {
+      throw new Error(`NpmLayerVersion only supports single-deployment architectures`);
+    }
+    const nodeArch = AWS_ARCH_TO_NODE_ARCH.get(awsArch[0]);
+    if (!nodeArch) {
+      throw new Error(`Architecutre '${awsArch}' not supported`);
+    }
 
-    const pkgJson = JSON.parse(execSync('npm ls --production --json', { cwd, encoding: 'utf8' }));
+    execSync(`npm i --omit=dev --platform=linux --arch=${nodeArch}`, { cwd });
+
+    const pkgJson = JSON.parse(execSync('npm ls --omit=dev --json', { cwd, encoding: 'utf8' }));
     this.packagedDependencies = Object.keys(pkgJson['dependencies']);
 
     this.layerVersion = new LayerVersion(scope, `${id}LayerVersion`, {


### PR DESCRIPTION
This addresses the architecture part of #4 , however doesn't allow full customization.  

I'm not sure we want that, as our SW could execute arbitrary commands (see execSync).

Will this be sufficient for arm64 sharp support, or do we need libc as well?